### PR TITLE
android: drop Google Play dependency metadata from APK signing block

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -71,6 +71,14 @@ android {
             useLegacyPackaging true
         }
     }
+
+    // Strip Google Play "Dependency metadata" block from the APK signing block.
+    // F-Droid's reproducible-build check rejects it as an extra signing block.
+    // See: https://gitlab.com/fdroid/fdroiddata/-/work_items/3330
+    dependenciesInfo {
+        includeInApk = false
+        includeInBundle = false
+    }
 }
 
 flutter {


### PR DESCRIPTION
F-Droid's reproducible-build check rejects the AGP-injected "Dependency metadata" block as an extra signing block. Disable it via the dependenciesInfo DSL.

See: https://gitlab.com/fdroid/fdroiddata/-/work_items/3330

For https://github.com/anywherelan/awl/issues/31