### PR TITLE
Add VPN Gateway, redesign Status/Peers screens

### DIFF
--- a/android/app/src/main/kotlin/com/anywherelan/awl/AppConfig.kt
+++ b/android/app/src/main/kotlin/com/anywherelan/awl/AppConfig.kt
@@ -3,7 +3,9 @@ package com.anywherelan.awl
 import org.json.JSONObject
 
 data class AppConfig(
-    val vpn: VpnConfig
+    val vpn: VpnConfig,
+    val vpnGateway: VPNGatewayConfig,
+    val dns: DnsConfig,
 ) {
     companion object {
         fun fromJson(jsonString: String): AppConfig {
@@ -16,7 +18,25 @@ data class AppConfig(
                 ipNet = vpnJson.getString("ipNet")
             )
 
-            return AppConfig(vpnConfig)
+            val dnsJson = root.optJSONObject("dns")
+            val dnsConfig = DnsConfig(
+                upstreamDNSAddress = dnsJson?.optString("upstreamDNSAddress", "") ?: ""
+            )
+
+            // gateway is optional for forward-compat with older configs that
+            // pre-date this section; treat a missing object as all-defaults.
+            val gatewayJson = root.optJSONObject("vpnGateway")
+            val gatewayConfig = if (gatewayJson != null) {
+                VPNGatewayConfig(
+                    clientEnabled = gatewayJson.optBoolean("clientEnabled", false),
+                    gatewayPeerID = gatewayJson.optString("gatewayPeerID", ""),
+                    serverEnabled = gatewayJson.optBoolean("serverEnabled", false),
+                )
+            } else {
+                VPNGatewayConfig(false, "", false)
+            }
+
+            return AppConfig(vpnConfig, gatewayConfig, dnsConfig)
         }
     }
 }
@@ -25,4 +45,35 @@ data class VpnConfig(
     val disableVPNInterface: Boolean,
     val interfaceName: String,
     val ipNet: String
+)
+
+// GatewayConfig mirrors GatewayConfig in github.com/anywherelan/awl/config.
+//
+// `clientEnabled` — full-tunnel mode is on; we should add a 0.0.0.0/0 route to the
+//   VpnService.Builder and register a SocketProtector so libp2p traffic
+//   bypasses the TUN. Without the protector AWL would route its own peer
+//   connections back into itself and never reach the exit node.
+//
+// `gatewayPeerID` — selected exit node, informational on the Android side.
+//
+// `serverEnabled` — this device offers itself as a VPN gateway. Acting
+//   as an exit node from Android is not supported (no MASQUERADE on a
+//   non-rooted device), but we still parse the field so that the value
+//   round-trips through GetConfig/UpdateConfig if the user toggles it.
+data class VPNGatewayConfig(
+    val clientEnabled: Boolean,
+    val gatewayPeerID: String,
+    val serverEnabled: Boolean,
+)
+
+// DnsConfig mirrors DNSConfig in github.com/anywherelan/awl/config.
+//
+// `upstreamDNSAddress` — the public resolver (host:port) the Go side forwards
+//   non-.awl queries to. On Android there is no in-process awl resolver
+//   (binding :53 needs root; see the TODO in the Go DNSService), so we instead
+//   point VpnService at this resolver directly via addDnsServer when full-tunnel
+//   (gateway client) mode is on, so DNS does not leak around the tunnel. The
+//   port is stripped — VpnService.addDnsServer takes a bare IP.
+data class DnsConfig(
+    val upstreamDNSAddress: String,
 )

--- a/android/app/src/main/kotlin/com/anywherelan/awl/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/anywherelan/awl/MainActivity.kt
@@ -5,15 +5,23 @@ import android.net.VpnService
 import android.os.Build
 import androidx.annotation.NonNull
 import anywherelan.Anywherelan
+import anywherelan.SocketProtector
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.BinaryMessenger.TaskQueue
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.StandardMethodCodec
+import java.net.URI
+import java.net.URISyntaxException
 
 
 class MainActivity : FlutterActivity() {
     private val CHANNEL = "anywherelan"
+
+    // The active VpnService instance, retained so the TUN can be re-established
+    // at runtime (see establishTun / the "reconfigure_vpn" method). Null when no
+    // VPN interface is active.
+    private var vpnService: MyVpnService? = null
 
     override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
@@ -42,6 +50,7 @@ class MainActivity : FlutterActivity() {
 
                     if (!config.vpn.disableVPNInterface) {
                         val service = MyVpnService()
+                        vpnService = service
                         val requestPermissionIntent = VpnService.prepare(this.context)
                         if (requestPermissionIntent != null) {
                             result.error("error", "vpn not authorized", null)
@@ -50,45 +59,51 @@ class MainActivity : FlutterActivity() {
                         }
                         context.startService(Intent(context, MyVpnService::class.java))
 
-
-                        val tunnelName = config.vpn.interfaceName
-                        val ipNetParts = config.vpn.ipNet.split("/")
-                        if (ipNetParts.size != 2) {
-                            throw Exception("Invalid ipNet format: ${config.vpn.ipNet}")
-                        }
-                        val networkAddress = ipNetParts[0]
-                        val networkAddressMask = ipNetParts[1].toInt()
-
-                        val builder: VpnService.Builder = service.builder
-                        builder.setSession(tunnelName)
-                        builder.addAddress(networkAddress, networkAddressMask)
-                        builder.setMtu(3500)
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                            builder.setBlocking(true)
-                        }
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                            builder.setMetered(false)
-                        }
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                            service.setUnderlyingNetworks(null)
-                        }
-
-                        builder.establish().use { tun ->
-                            if (tun == null) throw Exception("TUN_CREATION_ERROR")
-                            tunFd = tun!!.detachFd()
-                        }
+                        tunFd = establishTun(service, config)
                     }
 
                     try {
-                        Anywherelan.startServer(tunFd)
+                        // Always register the protector when a VPN interface is
+                        // active, regardless of the current gateway state. The Go
+                        // side marks every libp2p socket at dial time; if the user
+                        // later toggles gateway client mode on at runtime, the
+                        // connections opened before the toggle must already be
+                        // protected, otherwise they would loop back through the
+                        // 0.0.0.0/0 route. When gateway is off, protect() is a
+                        // no-op (libp2p traffic does not traverse the TUN anyway).
+                        val service = vpnService
+                        val protector: SocketProtector? =
+                            if (service != null) VpnSocketProtector(service) else null
+                        Anywherelan.startServer(tunFd, protector)
                         val apiAddress = Anywherelan.getApiAddress()
                         result.success(apiAddress)
                     } catch (e: Exception) {
                         result.error("error", e.message, null)
                     }
                 }
+                "reconfigure_vpn" -> {
+                    try {
+                        val service = vpnService
+                        val config = AppConfig.fromJson(Anywherelan.getConfig())
+                        if (config.vpn.disableVPNInterface || service == null) {
+                            // No active VPN interface to reconfigure.
+                            result.success(null)
+                            return@setMethodCallHandler
+                        }
+                        // Re-establish the TUN with the routes for the current
+                        // (already-persisted) gateway state and hot-swap the fresh
+                        // fd into the running backend. P2P stays up: its sockets
+                        // are already protected and the swap replaces only the fd.
+                        val newFd = establishTun(service, config)
+                        Anywherelan.updateTunDevice(newFd)
+                        result.success(null)
+                    } catch (e: Exception) {
+                        result.error("error", e.message, null)
+                    }
+                }
                 "stop_server" -> {
                     Anywherelan.stopServer()
+                    vpnService = null
                     result.success(null)
                 }
                 "import_config" -> {
@@ -106,6 +121,75 @@ class MainActivity : FlutterActivity() {
             }
         }
     }
+
+    // establishTun (re)creates the VpnService TUN interface from config and
+    // returns its file descriptor. Routes depend on gateway client mode: when
+    // on, route everything (0.0.0.0/0 + ::/0); when off, addAddress already
+    // routes the awl subnet on-link, so no explicit route is added. The fd is
+    // detached and handed to the Go side, which owns and closes it. Used both at
+    // startup and by "reconfigure_vpn" for runtime gateway toggling, where a
+    // fresh establish() is a seamless handover that swaps only the tun fd.
+    private fun establishTun(service: MyVpnService, config: AppConfig): Int {
+        val ipNetParts = config.vpn.ipNet.split("/")
+        if (ipNetParts.size != 2) {
+            throw Exception("Invalid ipNet format: ${config.vpn.ipNet}")
+        }
+        val networkAddress = ipNetParts[0]
+        val networkAddressMask = ipNetParts[1].toInt()
+
+        val builder: VpnService.Builder = service.builder
+        builder.setSession(config.vpn.interfaceName)
+        builder.addAddress(networkAddress, networkAddressMask)
+        builder.setMtu(3500)
+
+        if (config.vpnGateway.clientEnabled) {
+            builder.addRoute("0.0.0.0", 0)
+            builder.addRoute("::", 0)
+
+            // Full-tunnel mode: pin DNS to the configured upstream so queries go
+            // through the TUN (and the exit node) instead of leaking to the
+            // device's own resolver. The Go DNSService cannot take over DNS on
+            // Android (no awl :53 listener without root), so the host owns this.
+            val dnsHost = hostFromAddress(config.dns.upstreamDNSAddress)
+            if (dnsHost.isNotEmpty()) {
+                builder.addDnsServer(dnsHost)
+            }
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            builder.setBlocking(true)
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            builder.setMetered(false)
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            service.setUnderlyingNetworks(null)
+        }
+
+        var tunFd = 0
+        builder.establish().use { tun ->
+            if (tun == null) throw Exception("TUN_CREATION_ERROR")
+            tunFd = tun.detachFd()
+        }
+        return tunFd
+    }
+
+    // hostFromAddress extracts the bare IP from a "host:port" upstream DNS
+    // address (config stores host:port for the Go resolver; VpnService.addDnsServer
+    // wants a bare IP). Parsing is delegated to java.net.URI: the "//" prefix
+    // makes the string a network authority, so getHost() splits off the port.
+    // URI returns IPv6 hosts bracketed per RFC 2732, so strip the brackets.
+    // Returns "" for blank input and falls back to the trimmed input if it is
+    // not a parseable authority.
+    private fun hostFromAddress(addr: String): String {
+        val trimmed = addr.trim()
+        if (trimmed.isEmpty()) return ""
+        return try {
+            URI("//$trimmed").host?.removeSurrounding("[", "]") ?: trimmed
+        } catch (e: URISyntaxException) {
+            trimmed
+        }
+    }
 }
 
 class MyVpnService : android.net.VpnService() {
@@ -115,5 +199,26 @@ class MyVpnService : android.net.VpnService() {
     override fun onDestroy() {
         Anywherelan.stopServer()
         super.onDestroy()
+    }
+}
+
+// VpnSocketProtector adapts the VpnService.protect(fd) method to the
+// gomobile-generated anywherelan.SocketProtector interface. Defined as a
+// wrapper rather than implemented directly on MyVpnService so that the Go
+// method name (protectSocket) does not collide with VpnService.protect when
+// the gomobile binding lower-cases it for Java.
+//
+// Note: SocketProtector is a top-level interface in the gomobile-generated
+// `anywherelan` Java package, NOT a nested class of `Anywherelan`. The
+// `Anywherelan` class only holds package-level functions (Setup, GetConfig,
+// StartServerWithProtector, …); Go interfaces become sibling top-level
+// interfaces in the same Java package.
+class VpnSocketProtector(private val vpnService: VpnService) : SocketProtector {
+    // gomobile maps Go int32 to Java int, so the parameter type here is Int,
+    // not Long. (Go int would map to Long; we deliberately used int32 in
+    // SocketProtector.ProtectSocket to keep the parameter the same width as
+    // VpnService.protect(int) for a clean delegation.)
+    override fun protectSocket(fd: Int): Boolean {
+        return vpnService.protect(fd)
     }
 }

--- a/lib/api.dart
+++ b/lib/api.dart
@@ -27,6 +27,12 @@ const exportServerConfigPath = "${v0Prefix}settings/export_server_config";
 const listAvailableProxiesPath = "${v0Prefix}settings/list_proxies";
 const updateProxySettingsPath = "${v0Prefix}settings/set_proxy";
 
+// VPN Gateway
+const enableVPNGatewayClientPath = "${v0Prefix}vpn_gateway/client/enable";
+const disableVPNGatewayClientPath = "${v0Prefix}vpn_gateway/client/disable";
+const listAvailableVPNGatewaysPath = "${v0Prefix}vpn_gateway/client/list_available";
+const setVPNGatewayServerEnabledPath = "${v0Prefix}vpn_gateway/server/set_enabled";
+
 // Debug
 const getP2pDebugInfoPath = "${v0Prefix}debug/p2p_info";
 const getDebugLogPath = "${v0Prefix}debug/log";
@@ -77,6 +83,16 @@ class ApiClient {
       return ListAvailableProxiesResponse.fromJson(parsed);
     } catch (e, s) {
       Error.throwWithStackTrace(Exception('Failed to fetchAvailableProxies: $e'), s);
+    }
+  }
+
+  Future<ListAvailableVPNGatewaysResponse> fetchAvailableVPNGateways() async {
+    try {
+      final response = await _client.get(_uri(listAvailableVPNGatewaysPath));
+      final Map<String, dynamic> parsed = jsonDecode(response.body);
+      return ListAvailableVPNGatewaysResponse.fromJson(parsed);
+    } catch (e, s) {
+      Error.throwWithStackTrace(Exception('Failed to fetchAvailableVPNGateways: $e'), s);
     }
   }
 
@@ -146,6 +162,18 @@ class ApiClient {
 
   Future<String> removePeer(String peerID) {
     return _postJsonOrError(removePeerSettingsPath, PeerIDRequest(peerID).toJson());
+  }
+
+  Future<String> enableVPNGatewayClient(String gatewayPeerID) {
+    return _postJsonOrError(enableVPNGatewayClientPath, {"GatewayPeerID": gatewayPeerID});
+  }
+
+  Future<String> disableVPNGatewayClient() {
+    return _postJsonOrError(disableVPNGatewayClientPath, const {});
+  }
+
+  Future<String> setVPNGatewayServerEnabled(bool enabled) {
+    return _postJsonOrError(setVPNGatewayServerEnabledPath, {"Enabled": enabled});
   }
 
   // ---- private helpers ----

--- a/lib/entities.dart
+++ b/lib/entities.dart
@@ -15,6 +15,7 @@ class KnownPeer {
   final bool declined;
   final bool weAllowUsingAsExitNode;
   final bool allowedUsingAsExitNode;
+  final bool remoteVPNGatewayServerEnabled;
   final DateTime lastSeen;
   final List<ConnectionInfo> connections;
   final NetworkStats networkStats;
@@ -35,6 +36,7 @@ class KnownPeer {
     this.declined,
     this.weAllowUsingAsExitNode,
     this.allowedUsingAsExitNode,
+    this.remoteVPNGatewayServerEnabled,
     this.ping,
   );
 
@@ -85,6 +87,8 @@ class MyPeerInfo {
   final bool isAwlDNSSetAsSystem;
   @JsonKey(name: "SOCKS5")
   final SOCKS5Info socks5;
+  @JsonKey(name: "VPNGateway")
+  final VPNGatewayInfo vpnGateway;
 
   MyPeerInfo(
     this.peerID,
@@ -98,6 +102,7 @@ class MyPeerInfo {
     this.awlDNSAddress,
     this.isAwlDNSSetAsSystem,
     this.socks5,
+    this.vpnGateway,
   );
 
   factory MyPeerInfo.fromJson(Map<String, dynamic> json) => _$MyPeerInfoFromJson(json);
@@ -110,20 +115,83 @@ class SOCKS5Info {
   final String listenAddress;
   final bool proxyingEnabled;
   final bool listenerEnabled;
+  final bool connected;
   final String usingPeerID;
   final String usingPeerName;
+  final String usingPeerPublicIP;
+  @JsonKey(fromJson: _durationFromNanoseconds, toJson: _durationToNanoseconds)
+  final Duration usingPeerPing;
+  final bool usingPeerThroughRelay;
 
   SOCKS5Info(
     this.listenAddress,
     this.proxyingEnabled,
     this.listenerEnabled,
+    this.connected,
     this.usingPeerID,
     this.usingPeerName,
+    this.usingPeerPublicIP,
+    this.usingPeerPing,
+    this.usingPeerThroughRelay,
   );
 
   factory SOCKS5Info.fromJson(Map<String, dynamic> json) => _$SOCKS5InfoFromJson(json);
 
   Map<String, dynamic> toJson() => _$SOCKS5InfoToJson(this);
+}
+
+@JsonSerializable(fieldRename: FieldRename.pascal)
+class VPNGatewayInfo {
+  final bool clientEnabled;
+  final bool serverEnabled;
+  final String gatewayPeerID;
+  final String gatewayPeerName;
+  final bool connected;
+  final String gatewayPublicIP;
+  @JsonKey(fromJson: _durationFromNanoseconds, toJson: _durationToNanoseconds)
+  final Duration gatewayPing;
+  final bool gatewayThroughRelay;
+
+  VPNGatewayInfo(
+    this.clientEnabled,
+    this.gatewayPeerID,
+    this.gatewayPeerName,
+    this.connected,
+    this.serverEnabled,
+    this.gatewayPublicIP,
+    this.gatewayPing,
+    this.gatewayThroughRelay,
+  );
+
+  factory VPNGatewayInfo.fromJson(Map<String, dynamic> json) => _$VPNGatewayInfoFromJson(json);
+
+  Map<String, dynamic> toJson() => _$VPNGatewayInfoToJson(this);
+}
+
+@JsonSerializable(fieldRename: FieldRename.pascal)
+class AvailableVPNGateway {
+  final String peerID;
+  final String peerName;
+  final bool connected;
+
+  AvailableVPNGateway(this.peerID, this.peerName, this.connected);
+
+  factory AvailableVPNGateway.fromJson(Map<String, dynamic> json) => _$AvailableVPNGatewayFromJson(json);
+
+  Map<String, dynamic> toJson() => _$AvailableVPNGatewayToJson(this);
+}
+
+@JsonSerializable(fieldRename: FieldRename.pascal)
+class ListAvailableVPNGatewaysResponse {
+  @JsonKey(name: "VPNGateways", defaultValue: <AvailableVPNGateway>[])
+  final List<AvailableVPNGateway> vpnGateways;
+
+  ListAvailableVPNGatewaysResponse(this.vpnGateways);
+
+  factory ListAvailableVPNGatewaysResponse.fromJson(Map<String, dynamic> json) =>
+      _$ListAvailableVPNGatewaysResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ListAvailableVPNGatewaysResponseToJson(this);
 }
 
 @JsonSerializable(fieldRename: FieldRename.pascal)
@@ -177,8 +245,9 @@ class ListAvailableProxiesResponse {
 class AvailableProxy {
   final String peerID;
   final String peerName;
+  final bool connected;
 
-  AvailableProxy(this.peerID, this.peerName);
+  AvailableProxy(this.peerID, this.peerName, this.connected);
 
   factory AvailableProxy.fromJson(Map<String, dynamic> json) => _$AvailableProxyFromJson(json);
 

--- a/lib/entities.g.dart
+++ b/lib/entities.g.dart
@@ -24,6 +24,7 @@ KnownPeer _$KnownPeerFromJson(Map<String, dynamic> json) => KnownPeer(
   json['Declined'] as bool,
   json['WeAllowUsingAsExitNode'] as bool,
   json['AllowedUsingAsExitNode'] as bool,
+  json['RemoteVPNGatewayServerEnabled'] as bool,
   _durationFromNanoseconds((json['Ping'] as num).toInt()),
 );
 
@@ -38,6 +39,7 @@ Map<String, dynamic> _$KnownPeerToJson(KnownPeer instance) => <String, dynamic>{
   'Declined': instance.declined,
   'WeAllowUsingAsExitNode': instance.weAllowUsingAsExitNode,
   'AllowedUsingAsExitNode': instance.allowedUsingAsExitNode,
+  'RemoteVPNGatewayServerEnabled': instance.remoteVPNGatewayServerEnabled,
   'LastSeen': instance.lastSeen.toIso8601String(),
   'Connections': instance.connections,
   'NetworkStats': instance.networkStats,
@@ -74,6 +76,7 @@ MyPeerInfo _$MyPeerInfoFromJson(Map<String, dynamic> json) => MyPeerInfo(
   json['AwlDNSAddress'] as String,
   json['IsAwlDNSSetAsSystem'] as bool,
   SOCKS5Info.fromJson(json['SOCKS5'] as Map<String, dynamic>),
+  VPNGatewayInfo.fromJson(json['VPNGateway'] as Map<String, dynamic>),
 );
 
 Map<String, dynamic> _$MyPeerInfoToJson(MyPeerInfo instance) =>
@@ -89,14 +92,19 @@ Map<String, dynamic> _$MyPeerInfoToJson(MyPeerInfo instance) =>
       'AwlDNSAddress': instance.awlDNSAddress,
       'IsAwlDNSSetAsSystem': instance.isAwlDNSSetAsSystem,
       'SOCKS5': instance.socks5,
+      'VPNGateway': instance.vpnGateway,
     };
 
 SOCKS5Info _$SOCKS5InfoFromJson(Map<String, dynamic> json) => SOCKS5Info(
   json['ListenAddress'] as String,
   json['ProxyingEnabled'] as bool,
   json['ListenerEnabled'] as bool,
+  json['Connected'] as bool,
   json['UsingPeerID'] as String,
   json['UsingPeerName'] as String,
+  json['UsingPeerPublicIP'] as String,
+  _durationFromNanoseconds((json['UsingPeerPing'] as num).toInt()),
+  json['UsingPeerThroughRelay'] as bool,
 );
 
 Map<String, dynamic> _$SOCKS5InfoToJson(SOCKS5Info instance) =>
@@ -104,9 +112,65 @@ Map<String, dynamic> _$SOCKS5InfoToJson(SOCKS5Info instance) =>
       'ListenAddress': instance.listenAddress,
       'ProxyingEnabled': instance.proxyingEnabled,
       'ListenerEnabled': instance.listenerEnabled,
+      'Connected': instance.connected,
       'UsingPeerID': instance.usingPeerID,
       'UsingPeerName': instance.usingPeerName,
+      'UsingPeerPublicIP': instance.usingPeerPublicIP,
+      'UsingPeerPing': _durationToNanoseconds(instance.usingPeerPing),
+      'UsingPeerThroughRelay': instance.usingPeerThroughRelay,
     };
+
+VPNGatewayInfo _$VPNGatewayInfoFromJson(Map<String, dynamic> json) =>
+    VPNGatewayInfo(
+      json['ClientEnabled'] as bool,
+      json['GatewayPeerID'] as String,
+      json['GatewayPeerName'] as String,
+      json['Connected'] as bool,
+      json['ServerEnabled'] as bool,
+      json['GatewayPublicIP'] as String,
+      _durationFromNanoseconds((json['GatewayPing'] as num).toInt()),
+      json['GatewayThroughRelay'] as bool,
+    );
+
+Map<String, dynamic> _$VPNGatewayInfoToJson(VPNGatewayInfo instance) =>
+    <String, dynamic>{
+      'ClientEnabled': instance.clientEnabled,
+      'ServerEnabled': instance.serverEnabled,
+      'GatewayPeerID': instance.gatewayPeerID,
+      'GatewayPeerName': instance.gatewayPeerName,
+      'Connected': instance.connected,
+      'GatewayPublicIP': instance.gatewayPublicIP,
+      'GatewayPing': _durationToNanoseconds(instance.gatewayPing),
+      'GatewayThroughRelay': instance.gatewayThroughRelay,
+    };
+
+AvailableVPNGateway _$AvailableVPNGatewayFromJson(Map<String, dynamic> json) =>
+    AvailableVPNGateway(
+      json['PeerID'] as String,
+      json['PeerName'] as String,
+      json['Connected'] as bool,
+    );
+
+Map<String, dynamic> _$AvailableVPNGatewayToJson(
+  AvailableVPNGateway instance,
+) => <String, dynamic>{
+  'PeerID': instance.peerID,
+  'PeerName': instance.peerName,
+  'Connected': instance.connected,
+};
+
+ListAvailableVPNGatewaysResponse _$ListAvailableVPNGatewaysResponseFromJson(
+  Map<String, dynamic> json,
+) => ListAvailableVPNGatewaysResponse(
+  (json['VPNGateways'] as List<dynamic>?)
+          ?.map((e) => AvailableVPNGateway.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      [],
+);
+
+Map<String, dynamic> _$ListAvailableVPNGatewaysResponseToJson(
+  ListAvailableVPNGatewaysResponse instance,
+) => <String, dynamic>{'VPNGateways': instance.vpnGateways};
 
 NetworkStats _$NetworkStatsFromJson(Map<String, dynamic> json) => NetworkStats(
   (json['TotalIn'] as num).toInt(),
@@ -150,10 +214,18 @@ Map<String, dynamic> _$ListAvailableProxiesResponseToJson(
 ) => <String, dynamic>{'Proxies': instance.proxies};
 
 AvailableProxy _$AvailableProxyFromJson(Map<String, dynamic> json) =>
-    AvailableProxy(json['PeerID'] as String, json['PeerName'] as String);
+    AvailableProxy(
+      json['PeerID'] as String,
+      json['PeerName'] as String,
+      json['Connected'] as bool,
+    );
 
 Map<String, dynamic> _$AvailableProxyToJson(AvailableProxy instance) =>
-    <String, dynamic>{'PeerID': instance.peerID, 'PeerName': instance.peerName};
+    <String, dynamic>{
+      'PeerID': instance.peerID,
+      'PeerName': instance.peerName,
+      'Connected': instance.connected,
+    };
 
 FriendRequestReply _$FriendRequestReplyFromJson(Map<String, dynamic> json) =>
     FriendRequestReply(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -115,6 +115,22 @@ class MyApp extends StatelessWidget {
   }
 }
 
+/// Max width for the Status content (device header + Network/Gateway/Proxy
+/// cards). Capping the whole column — rather than the individual Address /
+/// Exit-peer fields — lets those fields stretch to the card width while the
+/// column stays a readable form width instead of sprawling across a wide
+/// screen. Applied at both layout call sites below.
+const double _kStatusContentMaxWidth = 480;
+
+/// Max width for the Peers content (header + list). Like the Status cap, it
+/// keeps the list from sprawling on wide screens. Kept wider than
+/// [_kStatusContentMaxWidth] because the expanded peer-details panel needs
+/// room for its 2-column grid: its column width minus the card chrome (~36px:
+/// 4px left border + 16+16 body padding) must stay ≥
+/// `_kPeerDetailsTwoColumnMinWidth` (430) or the details collapse to a single
+/// column even on large monitors.
+const double _kPeersContentMaxWidth = 600;
+
 class HomeScreen extends ConsumerStatefulWidget {
   static String routeName = "/";
 
@@ -139,7 +155,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     _notificationsService.init();
     WidgetsBinding.instance.addObserver(this);
 
-    _tabController = TabController(vsync: this, length: 2, initialIndex: 1);
+    _tabController = TabController(vsync: this, length: 2, initialIndex: 0);
     _tabController.addListener(() {
       // to trigger build and refresh FloatingActionButton
       setState(() {});
@@ -210,8 +226,26 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
             child: TabBarView(
               controller: _tabController,
               children: [
-                Padding(padding: const EdgeInsets.all(16), child: StatusPage()),
-                Padding(padding: const EdgeInsets.symmetric(horizontal: 16), child: PeersListPage()),
+                Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Align(
+                    alignment: Alignment.topCenter,
+                    child: ConstrainedBox(
+                      constraints: const BoxConstraints(maxWidth: _kStatusContentMaxWidth),
+                      child: StatusPage(),
+                    ),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Align(
+                    alignment: Alignment.topCenter,
+                    child: ConstrainedBox(
+                      constraints: const BoxConstraints(maxWidth: _kPeersContentMaxWidth),
+                      child: PeersListPage(),
+                    ),
+                  ),
+                ),
               ],
             ),
           ),
@@ -263,23 +297,35 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
             SizedBox(width: spaceBetweenItems),
             Flexible(
               flex: 4,
-              child: Column(
-                children: [
-                  _buildPeersHeader(),
-                  Expanded(child: PeersListPage(showCounter: false)),
-                  SizedBox(height: 20),
-                ],
+              child: Align(
+                alignment: Alignment.topCenter,
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: _kPeersContentMaxWidth),
+                  child: Column(
+                    children: [
+                      _buildPeersHeader(),
+                      Expanded(child: PeersListPage(showCounter: false)),
+                      SizedBox(height: 20),
+                    ],
+                  ),
+                ),
               ),
             ),
             SizedBox(width: spaceBetweenItems),
             Flexible(
               flex: 3,
-              child: Column(
-                children: [
-                  _buildDeviceHeaderSection(),
-                  Expanded(child: StatusPage(showDeviceHeader: false)),
-                  SizedBox(height: 20),
-                ],
+              child: Align(
+                alignment: Alignment.topCenter,
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: _kStatusContentMaxWidth),
+                  child: Column(
+                    children: [
+                      _buildDeviceHeaderSection(),
+                      Expanded(child: StatusPage(showDeviceHeader: false)),
+                      SizedBox(height: 20),
+                    ],
+                  ),
+                ),
               ),
             ),
             SizedBox(width: spaceBetweenItems),

--- a/lib/peer_settings_screen.dart
+++ b/lib/peer_settings_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:anywherelan/common.dart';
 import 'package:anywherelan/entities.dart';
 import 'package:anywherelan/providers.dart';
 import 'package:flutter/material.dart';
@@ -91,7 +92,16 @@ class _KnownPeerSettingsScreenState extends ConsumerState<KnownPeerSettingsScree
       return Container();
     }
 
-    return PeerSettingsView(peerConfig: _peerConfig!, onSave: _onSave, onRemove: _onRemove);
+    final knownPeers = ref.watch(knownPeersProvider).valueOrNull;
+    final knownPeer = knownPeers?.where((p) => p.peerID == _peerID).firstOrNull;
+
+    return PeerSettingsView(
+      peerConfig: _peerConfig!,
+      remoteAllowsUsAsExitNode: knownPeer?.allowedUsingAsExitNode,
+      remoteServesAsVPNGateway: knownPeer?.remoteVPNGatewayServerEnabled,
+      onSave: _onSave,
+      onRemove: _onRemove,
+    );
   }
 }
 
@@ -100,10 +110,19 @@ class _KnownPeerSettingsScreenState extends ConsumerState<KnownPeerSettingsScree
 /// Tests target this widget directly with fixture data.
 class PeerSettingsView extends StatefulWidget {
   final KnownPeerConfig peerConfig;
+  final bool? remoteAllowsUsAsExitNode;
+  final bool? remoteServesAsVPNGateway;
   final Future<String> Function(UpdateKnownPeerConfigRequest)? onSave;
   final Future<String> Function()? onRemove;
 
-  const PeerSettingsView({super.key, required this.peerConfig, this.onSave, this.onRemove});
+  const PeerSettingsView({
+    super.key,
+    required this.peerConfig,
+    this.remoteAllowsUsAsExitNode,
+    this.remoteServesAsVPNGateway,
+    this.onSave,
+    this.onRemove,
+  });
 
   @override
   State<PeerSettingsView> createState() => _PeerSettingsViewState();
@@ -369,7 +388,7 @@ class _PeerSettingsViewState extends State<PeerSettingsView> {
           _buildSectionTitle('PERMISSIONS'),
           Row(
             children: [
-              Icon(Icons.vpn_key, color: Theme.of(context).colorScheme.onSurfaceVariant),
+              Icon(Icons.alt_route_rounded, color: Theme.of(context).colorScheme.onSurfaceVariant),
               SizedBox(width: 16),
               Expanded(
                 child: Column(
@@ -377,7 +396,7 @@ class _PeerSettingsViewState extends State<PeerSettingsView> {
                   children: [
                     Text('Allow as exit node', style: TextStyle(fontSize: 16)),
                     Text(
-                      'Allow this peer to route traffic through your network',
+                      'Allow this device to route traffic through your network',
                       style: TextStyle(fontSize: 13, color: Theme.of(context).colorScheme.onSurfaceVariant),
                     ),
                   ],
@@ -386,11 +405,16 @@ class _PeerSettingsViewState extends State<PeerSettingsView> {
               Tooltip(
                 triggerMode: TooltipTriggerMode.tap,
                 message:
-                    'This allows peer to pass their traffic through your network via SOCKS5 proxy, for instance peer will have access to your local WiFi network',
-                child: IconButton(
-                  icon: Icon(Icons.info_outline, size: 20),
-                  onPressed: null,
-                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    'Allows this device to route their traffic through your device. '
+                    'Applies to both SOCKS5 proxy and VPN gateway — for instance, the device will '
+                    'have access to your local Wi-Fi network.',
+                child: Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 8),
+                  child: Icon(
+                    Icons.info_outline,
+                    size: 20,
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
                 ),
               ),
               Switch(
@@ -403,7 +427,51 @@ class _PeerSettingsViewState extends State<PeerSettingsView> {
               ),
             ],
           ),
+          if (widget.remoteAllowsUsAsExitNode != null && widget.remoteServesAsVPNGateway != null) ...[
+            SizedBox(height: 16),
+            _buildSectionTitle('THEIR PERMISSIONS'),
+            _buildRemoteFlagTile(
+              context,
+              icon: Icons.logout_rounded,
+              label: 'Allows us as their exit node',
+              value: widget.remoteAllowsUsAsExitNode!,
+            ),
+            _buildRemoteFlagTile(
+              context,
+              icon: Icons.vpn_lock_outlined,
+              label: 'Serves as a VPN gateway',
+              value: widget.remoteServesAsVPNGateway!,
+            ),
+            Padding(
+              padding: const EdgeInsets.only(top: 8, left: 16, right: 8),
+              child: Text(
+                'Only this device can change these from their device. Both must be allowed '
+                'for them to appear in your VPN gateway picker.',
+                style: TextStyle(fontSize: 12, color: Theme.of(context).colorScheme.onSurfaceVariant),
+              ),
+            ),
+          ],
         ],
+      ),
+    );
+  }
+
+  Widget _buildRemoteFlagTile(
+    BuildContext context, {
+    required IconData icon,
+    required String label,
+    required bool value,
+  }) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return ListTile(
+      contentPadding: EdgeInsets.zero,
+      visualDensity: VisualDensity.compact,
+      leading: Icon(icon, color: colorScheme.onSurfaceVariant),
+      title: Text(label, style: const TextStyle(fontSize: 16)),
+      trailing: StatusPill(
+        text: value ? 'Allowed' : 'Not allowed',
+        color: value ? successColor : colorScheme.onSurfaceVariant,
+        withDot: false,
       ),
     );
   }

--- a/lib/peers_list_tab.dart
+++ b/lib/peers_list_tab.dart
@@ -7,6 +7,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'connection_error.dart';
 
+/// Min width of the expanded peer-details panel at which it switches from
+/// single-column rows (label left, value right) to a 2-column grid. Measured
+/// against the panel's *actual* width via [LayoutBuilder] — not the global
+/// screen width — so it stays correct inside the side-by-side peers column.
+const double _kPeerDetailsTwoColumnMinWidth = 430;
+
 /// Adapter for [PeersListView] that reads [knownPeersProvider] via Riverpod.
 /// The pure presentation logic lives in [PeersListView].
 class PeersListPage extends ConsumerWidget {
@@ -27,6 +33,9 @@ class PeersListPage extends ConsumerWidget {
     final knownPeers = ref.watch(knownPeersProvider).valueOrNull;
     final myPeerInfo = ref.watch(myPeerInfoProvider).valueOrNull;
     final proxyExitPeerID = myPeerInfo?.socks5.usingPeerID;
+    final gatewayExitPeerID = (myPeerInfo?.vpnGateway.clientEnabled ?? false)
+        ? myPeerInfo?.vpnGateway.gatewayPeerID
+        : null;
 
     return ValueListenableBuilder<bool>(
       valueListenable: isServerAvailable,
@@ -39,6 +48,7 @@ class PeersListPage extends ConsumerWidget {
           peers: knownPeers,
           showCounter: showCounter,
           proxyExitPeerID: proxyExitPeerID,
+          gatewayExitPeerID: gatewayExitPeerID,
           onPeerSettings: (peer) => _onPeerSettings(context, peer),
           onShowQR: (peer) => _onShowQR(context, peer),
         );
@@ -54,6 +64,7 @@ class PeersListView extends StatefulWidget {
   final List<KnownPeer>? peers;
   final bool showCounter;
   final String? proxyExitPeerID;
+  final String? gatewayExitPeerID;
   final Future<void> Function(KnownPeer)? onPeerSettings;
   final Future<void> Function(KnownPeer)? onShowQR;
 
@@ -62,6 +73,7 @@ class PeersListView extends StatefulWidget {
     required this.peers,
     this.showCounter = true,
     this.proxyExitPeerID,
+    this.gatewayExitPeerID,
     this.onPeerSettings,
     this.onShowQR,
   });
@@ -145,6 +157,10 @@ class _PeersListViewState extends State<PeersListView> {
         widget.proxyExitPeerID != null &&
         widget.proxyExitPeerID!.isNotEmpty &&
         widget.proxyExitPeerID == peer.peerID;
+    final isGatewayExit =
+        widget.gatewayExitPeerID != null &&
+        widget.gatewayExitPeerID!.isNotEmpty &&
+        widget.gatewayExitPeerID == peer.peerID;
 
     return Card(
       margin: EdgeInsets.only(bottom: 12),
@@ -182,6 +198,7 @@ class _PeersListViewState extends State<PeersListView> {
                                 ),
                               ),
                               if (isProxyExit) ...[SizedBox(width: 12), _ExitBadge()],
+                              if (isGatewayExit) ...[SizedBox(width: 8), _GatewayBadge()],
                             ],
                           ),
                           SizedBox(height: 2),
@@ -231,8 +248,6 @@ class _PeersListViewState extends State<PeersListView> {
   }
 
   Widget _buildExpansionPanelBody(KnownPeer item) {
-    final isWide = MediaQuery.of(context).size.width > 850;
-
     // Collect detail entries as (label, value) pairs
     final details = <MapEntry<String, String>>[];
 
@@ -240,7 +255,7 @@ class _PeersListViewState extends State<PeersListView> {
       details.add(MapEntry("LAST SEEN", "${formatDuration(item.lastSeen.difference(DateTime.now()))} ago"));
     }
     details.add(MapEntry("VPN ADDRESS", "${item.domainName}.awl · ${item.ipAddr}"));
-    // Connections handled separately for widget
+    // Connections handled separately (a widget, not a simple string).
     details.add(MapEntry("USE AS EXIT", item.allowedUsingAsExitNode ? "Allowed" : "Denied"));
     details.add(MapEntry("OFFER AS EXIT", item.weAllowUsingAsExitNode ? "Allowed" : "Denied"));
     if (item.networkStats.totalIn != 0) {
@@ -258,84 +273,60 @@ class _PeersListViewState extends State<PeersListView> {
 
     final colorScheme = Theme.of(context).colorScheme;
 
-    // Connection widget (needs special handling — not a simple string)
-    Widget? connectionWidget;
-    if (item.connections.isNotEmpty) {
-      connectionWidget = _buildGridCell("CONNECTION", _buildConnectionsWidget(item.connections), colorScheme);
+    // CONNECTION slots in after VPN ADDRESS (index 1, or 2 if "last seen" leads).
+    final connectionInsertIdx = (!item.connected && item.confirmed) ? 2 : 1;
+
+    Color? valueColor(String label, String value) {
+      final isExitRow = label == "USE AS EXIT" || label == "OFFER AS EXIT";
+      if (!isExitRow) return null;
+      return value == "Allowed" ? successColor : colorScheme.onSurfaceVariant;
     }
 
-    Widget detailsWidget;
-    if (isWide) {
-      // 2-column grid on desktop
-      final cells = <Widget>[];
-      for (var entry in details) {
-        final isExitRow = entry.key == "USE AS EXIT" || entry.key == "OFFER AS EXIT";
-        final color = isExitRow
-            ? (entry.value == "Allowed" ? successColor : colorScheme.onSurfaceVariant)
-            : null;
-        cells.add(
-          _buildGridCell(
-            entry.key,
-            SelectableText(
-              entry.value,
-              style: TextStyle(fontSize: 14, color: color, fontWeight: FontWeight.w500),
-            ),
-            colorScheme,
-          ),
-        );
-      }
-      if (connectionWidget != null) {
-        // Insert connection after VPN ADDRESS (index 1, or 2 if last seen is present)
-        final insertIdx = (!item.connected && item.confirmed) ? 2 : 1;
-        cells.insert(insertIdx, connectionWidget);
-      }
-
-      detailsWidget = LayoutBuilder(
-        builder: (context, constraints) {
-          final availableWidth = constraints.maxWidth;
-          if (availableWidth < 300) {
-            // Fall back to single column on very narrow panels
-            return Column(crossAxisAlignment: CrossAxisAlignment.start, children: cells);
-          }
-          final cellWidth = (availableWidth - 16) / 2; // 2 columns with 16px gap
-          return Wrap(
-            spacing: 16,
-            runSpacing: 12,
-            children: cells.map((c) => SizedBox(width: cellWidth, child: c)).toList(),
-          );
-        },
-      );
-    } else {
-      // Single column rows on mobile: label left, value right
-      final rows = <Widget>[];
-      for (var entry in details) {
-        final isExitRow = entry.key == "USE AS EXIT" || entry.key == "OFFER AS EXIT";
-        final color = isExitRow
-            ? (entry.value == "Allowed" ? successColor : colorScheme.onSurfaceVariant)
-            : null;
-        rows.add(
-          _buildMobileRow(
-            entry.key,
-            SelectableText(
-              entry.value,
-              style: TextStyle(fontSize: 14, color: color, fontWeight: FontWeight.w500),
-            ),
-          ),
-        );
-      }
-      if (item.connections.isNotEmpty) {
-        final insertIdx = (!item.connected && item.confirmed) ? 2 : 1;
-        rows.insert(insertIdx, _buildMobileRow("CONNECTION", _buildConnectionsWidget(item.connections)));
-      }
-      detailsWidget = Column(children: rows);
-    }
+    Widget valueText(MapEntry<String, String> entry) => SelectableText(
+      entry.value,
+      style: TextStyle(fontSize: 14, color: valueColor(entry.key, entry.value), fontWeight: FontWeight.w500),
+    );
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Divider(height: 1, color: colorScheme.outlineVariant),
         SizedBox(height: 12),
-        detailsWidget,
+        // Decide 1- vs 2-column details by the panel's actual width, not the
+        // global screen width, so it stays correct inside the side-by-side
+        // peers column (and any future width cap).
+        LayoutBuilder(
+          builder: (context, constraints) {
+            final twoColumns = constraints.maxWidth >= _kPeerDetailsTwoColumnMinWidth;
+            if (twoColumns) {
+              final cells = <Widget>[
+                for (final entry in details) _buildGridCell(entry.key, valueText(entry), colorScheme),
+              ];
+              if (item.connections.isNotEmpty) {
+                cells.insert(
+                  connectionInsertIdx,
+                  _buildGridCell("CONNECTION", _buildConnectionsWidget(item.connections), colorScheme),
+                );
+              }
+              final cellWidth = (constraints.maxWidth - 16) / 2; // 2 columns with 16px gap
+              return Wrap(
+                spacing: 16,
+                runSpacing: 12,
+                children: cells.map((c) => SizedBox(width: cellWidth, child: c)).toList(),
+              );
+            }
+
+            // Single column: label left, value right.
+            final rows = <Widget>[for (final entry in details) _buildMobileRow(entry.key, valueText(entry))];
+            if (item.connections.isNotEmpty) {
+              rows.insert(
+                connectionInsertIdx,
+                _buildMobileRow("CONNECTION", _buildConnectionsWidget(item.connections)),
+              );
+            }
+            return Column(children: rows);
+          },
+        ),
         SizedBox(height: 12),
         Row(
           mainAxisAlignment: MainAxisAlignment.end,
@@ -445,9 +436,11 @@ class _PeersListViewState extends State<PeersListView> {
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              SelectableText(
-                connection.toString(),
-                style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w500),
+              Flexible(
+                child: SelectableText(
+                  connection.toString(),
+                  style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w500),
+                ),
               ),
               const SizedBox(width: 5),
               Tooltip(
@@ -486,7 +479,7 @@ class _ExitBadge extends StatelessWidget {
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
     return Tooltip(
-      message: 'SOCKS5 proxy traffic exits through this peer',
+      message: 'SOCKS5 proxy traffic exits through this device',
       child: Container(
         padding: const EdgeInsets.fromLTRB(8, 3, 10, 3),
         decoration: BoxDecoration(
@@ -500,7 +493,41 @@ class _ExitBadge extends StatelessWidget {
             Icon(Icons.exit_to_app_rounded, size: 14, color: colorScheme.onSurfaceVariant),
             const SizedBox(width: 6),
             Text(
-              'Exit node',
+              'SOCKS5 exit',
+              style: TextStyle(
+                fontSize: 11,
+                fontWeight: FontWeight.w500,
+                color: colorScheme.onSurfaceVariant,
+                height: 1.0,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _GatewayBadge extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Tooltip(
+      message: 'All internet traffic exits through this device (VPN gateway)',
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(8, 3, 10, 3),
+        decoration: BoxDecoration(
+          color: colorScheme.surfaceContainerHighest,
+          borderRadius: BorderRadius.circular(999),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Icon(Icons.vpn_lock_outlined, size: 14, color: colorScheme.onSurfaceVariant),
+            const SizedBox(width: 6),
+            Text(
+              'VPN gateway',
               style: TextStyle(
                 fontSize: 11,
                 fontWeight: FontWeight.w500,

--- a/lib/providers.dart
+++ b/lib/providers.dart
@@ -110,11 +110,22 @@ final availableProxiesProvider =
       AvailableProxiesNotifier.new,
     );
 
-/// Force-refresh all three providers. Throws if any fetch fails.
+class AvailableVPNGatewaysNotifier extends _PollingAsyncNotifier<ListAvailableVPNGatewaysResponse?> {
+  @override
+  Future<ListAvailableVPNGatewaysResponse?> fetch() => ref.read(apiProvider).fetchAvailableVPNGateways();
+}
+
+final availableVPNGatewaysProvider =
+    AsyncNotifierProvider<AvailableVPNGatewaysNotifier, ListAvailableVPNGatewaysResponse?>(
+      AvailableVPNGatewaysNotifier.new,
+    );
+
+/// Force-refresh all polling providers. Throws if any fetch fails.
 Future<void> refreshProviders(ProviderContainer container) => Future.wait([
   container.read(myPeerInfoProvider.notifier).refresh(),
   container.read(knownPeersProvider.notifier).refresh(),
   container.read(availableProxiesProvider.notifier).refresh(),
+  container.read(availableVPNGatewaysProvider.notifier).refresh(),
 ]);
 
 /// Retry refreshing all three providers every 200ms until all succeed

--- a/lib/server_interop/server_interop.dart
+++ b/lib/server_interop/server_interop.dart
@@ -23,3 +23,12 @@ bool isServerRunning() {
 Future<String> importConfig(String config) async {
   return importConfigImpl(config);
 }
+
+/// Re-applies the VPN routing to match the current backend config (e.g. after
+/// toggling gateway client mode). On Android this re-establishes the VPN
+/// interface and hot-swaps the new tun fd into the backend without dropping P2P
+/// connections; on other platforms it is a no-op. Returns "" on success or an
+/// error string.
+Future<String> reconfigureVpn() async {
+  return reconfigureVpnImpl();
+}

--- a/lib/server_interop/server_interop_mobile.dart
+++ b/lib/server_interop/server_interop_mobile.dart
@@ -58,3 +58,16 @@ Future<String> importConfigImpl(String config) async {
 
   return "";
 }
+
+Future<String> reconfigureVpnImpl() async {
+  if (!io.Platform.isAndroid) return "";
+
+  try {
+    await platform.invokeMethod('reconfigure_vpn');
+  } catch (e, s) {
+    developer.log('Failed to reconfigure vpn', error: e, stackTrace: s, name: 'server_interop');
+    return e.toString();
+  }
+
+  return "";
+}

--- a/lib/server_interop/server_interop_stub.dart
+++ b/lib/server_interop/server_interop_stub.dart
@@ -17,3 +17,7 @@ bool isServerRunningImpl() {
 Future<String> importConfigImpl(String config) async {
   throw UnsupportedError('Unsupported platform');
 }
+
+Future<String> reconfigureVpnImpl() async {
+  throw UnsupportedError('Unsupported platform');
+}

--- a/lib/server_interop/server_interop_web.dart
+++ b/lib/server_interop/server_interop_web.dart
@@ -30,3 +30,9 @@ bool isServerRunningImpl() {
 Future<String> importConfigImpl(String config) async {
   throw UnsupportedError('Unsupported for web');
 }
+
+Future<String> reconfigureVpnImpl() async {
+  // Web has no VPN interface; nothing to reconfigure. Returning "" (rather than
+  // throwing) lets callers invoke this unconditionally without a platform guard.
+  return "";
+}

--- a/lib/status_tab.dart
+++ b/lib/status_tab.dart
@@ -4,6 +4,8 @@ import 'package:anywherelan/common.dart';
 import 'package:anywherelan/connection_error.dart';
 import 'package:anywherelan/entities.dart';
 import 'package:anywherelan/providers.dart';
+import 'package:anywherelan/server_interop/server_interop.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -34,6 +36,34 @@ class _StatusPageState extends ConsumerState<StatusPage> {
     return response;
   }
 
+  Future<String> _onUpdateGateway(String gatewayPeerID) async {
+    final api = ref.read(apiProvider);
+    final response = gatewayPeerID.isEmpty
+        ? await api.disableVPNGatewayClient()
+        : await api.enableVPNGatewayClient(gatewayPeerID);
+    if (response == "") {
+      // The backend has persisted the new gateway state, but on Android it does
+      // not change routing by itself: the host must re-establish the VPN with
+      // the new routes and hot-swap the tun fd into the backend. This is a
+      // best-effort step — on failure the persisted state is ahead of actual
+      // routing, so we surface it rather than silently rolling back.
+      final reconfigureErr = await reconfigureVpn();
+      if (reconfigureErr.isNotEmpty && mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            backgroundColor: Theme.of(context).colorScheme.error,
+            content: Text('VPN routing not applied: $reconfigureErr. Restart the VPN to apply.'),
+          ),
+        );
+      }
+      await Future.wait([
+        ref.read(myPeerInfoProvider.notifier).refresh(),
+        ref.read(availableVPNGatewaysProvider.notifier).refresh(),
+      ]);
+    }
+    return response;
+  }
+
   Future<void> _onShowQR(MyPeerInfo peerInfo) async {
     await showQRDialog(context, peerInfo.peerID, peerInfo.name);
   }
@@ -46,6 +76,7 @@ class _StatusPageState extends ConsumerState<StatusPage> {
   Widget build(BuildContext context) {
     final peerInfo = ref.watch(myPeerInfoProvider).valueOrNull;
     final proxiesData = ref.watch(availableProxiesProvider).valueOrNull;
+    final gatewaysData = ref.watch(availableVPNGatewaysProvider).valueOrNull;
 
     return ValueListenableBuilder<bool>(
       valueListenable: isServerAvailable,
@@ -67,8 +98,10 @@ class _StatusPageState extends ConsumerState<StatusPage> {
         return StatusPageView(
           peerInfo: peerInfo,
           proxiesData: proxiesData,
+          gatewaysData: gatewaysData,
           showDeviceHeader: widget.showDeviceHeader,
           onUpdateProxy: _onUpdateProxy,
+          onUpdateGateway: _onUpdateGateway,
           onShowQR: peerInfo != null ? () => _onShowQR(peerInfo) : null,
           onShowSettings: () => _onShowSettings(peerInfo),
         );
@@ -83,8 +116,10 @@ class _StatusPageState extends ConsumerState<StatusPage> {
 class StatusPageView extends StatefulWidget {
   final MyPeerInfo? peerInfo;
   final ListAvailableProxiesResponse? proxiesData;
+  final ListAvailableVPNGatewaysResponse? gatewaysData;
   final bool showDeviceHeader;
   final Future<String> Function(String usingPeerID)? onUpdateProxy;
+  final Future<String> Function(String gatewayPeerID)? onUpdateGateway;
   final Future<void> Function()? onShowQR;
   final Future<void> Function()? onShowSettings;
 
@@ -92,8 +127,10 @@ class StatusPageView extends StatefulWidget {
     super.key,
     required this.peerInfo,
     this.proxiesData,
+    this.gatewaysData,
     this.showDeviceHeader = true,
     this.onUpdateProxy,
+    this.onUpdateGateway,
     this.onShowQR,
     this.onShowSettings,
   });
@@ -128,6 +165,12 @@ class _StatusPageViewState extends State<StatusPageView> {
           ],
           _NetworkCard(peerInfo: _peerInfo),
           SizedBox(height: 12),
+          _GatewayCard(
+            peerInfo: _peerInfo,
+            gatewaysData: widget.gatewaysData,
+            onUpdateGateway: widget.onUpdateGateway,
+          ),
+          SizedBox(height: 12),
           _ProxyCard(
             peerInfo: _peerInfo,
             proxiesData: widget.proxiesData,
@@ -152,10 +195,22 @@ class _NetworkCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
     final stats = peerInfo.networkStats;
-    final discoveryLow = peerInfo.connectedBootstrapPeers <= 1;
+    final connected = peerInfo.connectedBootstrapPeers;
+    final discoveryLow = connected <= 1;
+    // Hide the Discovery row at full health (≥2 connected). With the
+    // Online/Offline pill in the header, the row only earns its space
+    // when something is wrong or borderline.
+    final showDiscoveryRow = discoveryLow;
+    final isOnline = connected > 0;
 
     return _SectionCard(
-      header: const _CardHeader(title: 'Network'),
+      header: _CardHeader(
+        title: 'Network',
+        trailing: StatusPill(
+          text: isOnline ? 'Online' : 'Offline',
+          color: isOnline ? successColor : errorColor,
+        ),
+      ),
       // TODO: add 30s sparkline next to Download/Upload speeds when a ring
       // buffer of polled values lives in providers.dart (see plan file).
       children: [
@@ -177,16 +232,17 @@ class _NetworkCard extends StatelessWidget {
           subtitle: _reachabilitySubtitle(peerInfo.reachability),
           trailing: _ReachabilityChip(reachability: peerInfo.reachability),
         ),
-        _LabeledTile(
-          icon: Icons.hub_outlined,
-          label: 'Discovery nodes',
-          subtitle: discoveryLow ? 'At least 2 nodes recommended for reliable peer discovery.' : null,
-          trailing: _BootstrapValue(
-            connected: peerInfo.connectedBootstrapPeers,
-            total: peerInfo.totalBootstrapPeers,
-            errorColor: colorScheme.error,
+        if (showDiscoveryRow)
+          _LabeledTile(
+            icon: Icons.hub_outlined,
+            label: 'Discovery nodes',
+            subtitle: 'At least 2 nodes recommended for reliable peer discovery.',
+            trailing: _BootstrapValue(
+              connected: connected,
+              total: peerInfo.totalBootstrapPeers,
+              errorColor: colorScheme.error,
+            ),
           ),
-        ),
       ],
     );
   }
@@ -201,32 +257,229 @@ class _ProxyCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isActive = peerInfo.socks5.listenerEnabled && peerInfo.socks5.listenAddress.isNotEmpty;
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    final socks5 = peerInfo.socks5;
+    final listenerUp = socks5.listenerEnabled && socks5.listenAddress.isNotEmpty;
+    final hasUpstream = socks5.usingPeerID.isNotEmpty;
+
+    String pillText;
+    Color pillColor;
+    if (!listenerUp) {
+      pillText = 'Stopped';
+      pillColor = errorColor;
+    } else if (hasUpstream && !socks5.connected) {
+      pillText = 'Connecting…';
+      pillColor = colorScheme.tertiary;
+    } else {
+      pillText = 'Active';
+      pillColor = successColor;
+    }
+
+    final proxies = proxiesData?.proxies ?? const <AvailableProxy>[];
+    // Empty-state: no candidates AND nothing selected. Listener is up but
+    // every connection will fail until a friend allows us — say so plainly
+    // instead of rendering a useless one-item dropdown.
+    final showEmptyState = listenerUp && proxies.isEmpty && !hasUpstream;
 
     return _SectionCard(
       header: _CardHeader(
         title: 'SOCKS5 proxy',
-        trailing: StatusPill(
-          text: isActive ? 'Active' : 'Stopped',
-          color: isActive ? successColor : errorColor,
-        ),
+        trailing: StatusPill(text: pillText, color: pillColor),
       ),
       children: [
-        if (isActive)
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 4, 16, 4),
+          child: Text(
+            'Route specific app traffic through a remote device.',
+            style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurface.withValues(alpha: 0.72)),
+          ),
+        ),
+        if (listenerUp)
           Padding(
-            padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
-            child: _AddressField(address: peerInfo.socks5.listenAddress),
+            padding: const EdgeInsets.fromLTRB(16, 10, 16, 4),
+            child: _AddressField(address: socks5.listenAddress),
           ),
         Padding(
-          padding: const EdgeInsets.fromLTRB(16, 14, 16, 8),
-          child: _ExitThroughRow(
-            currentName: peerInfo.socks5.usingPeerName,
-            proxiesData: proxiesData,
-            onUpdateProxy: onUpdateProxy,
-          ),
+          padding: const EdgeInsets.fromLTRB(16, 10, 16, 8),
+          child: showEmptyState
+              ? Text(
+                  'The proxy listener is running, but no devices offer SOCKS5 exit — '
+                  'every connection will fail. Ask a remote device to allow you in their peer settings.',
+                  style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurface.withValues(alpha: 0.72)),
+                )
+              : _ExitThroughRow(
+                  currentName: socks5.usingPeerName,
+                  proxiesData: proxiesData,
+                  upstreamKnownOffline: hasUpstream && !socks5.connected,
+                  usingPublicIP: socks5.usingPeerPublicIP,
+                  usingPing: socks5.usingPeerPing,
+                  usingThroughRelay: socks5.usingPeerThroughRelay,
+                  onUpdateProxy: onUpdateProxy,
+                ),
         ),
       ],
     );
+  }
+}
+
+class _GatewayCard extends StatelessWidget {
+  final MyPeerInfo peerInfo;
+  final ListAvailableVPNGatewaysResponse? gatewaysData;
+  final Future<String> Function(String gatewayPeerID)? onUpdateGateway;
+
+  const _GatewayCard({required this.peerInfo, this.gatewaysData, this.onUpdateGateway});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    final gateway = peerInfo.vpnGateway;
+    final enabled = gateway.clientEnabled;
+    final connected = gateway.connected;
+
+    final pillText = !enabled ? 'Off' : (connected ? 'Active' : 'Connecting…');
+    final pillColor = !enabled
+        ? colorScheme.onSurfaceVariant
+        : (connected ? successColor : colorScheme.tertiary);
+
+    final gateways = gatewaysData?.vpnGateways ?? const <AvailableVPNGateway>[];
+    final hasCandidates = gateways.isNotEmpty;
+
+    return _SectionCard(
+      header: _CardHeader(
+        title: 'VPN Gateway',
+        trailing: StatusPill(text: pillText, color: pillColor),
+      ),
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 4, 16, 4),
+          child: Text(
+            'Route all internet traffic through a remote device.',
+            style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurface.withValues(alpha: 0.72)),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 14, 16, 8),
+          child: hasCandidates || enabled
+              ? _GatewayExitRow(
+                  selectedPeerID: gateway.gatewayPeerID,
+                  selectedName: gateway.gatewayPeerName,
+                  gateways: gateways,
+                  enabled: enabled,
+                  connected: connected,
+                  exitPing: gateway.gatewayPing,
+                  exitThroughRelay: gateway.gatewayThroughRelay,
+                  exitPublicIP: gateway.gatewayPublicIP,
+                  onUpdateGateway: onUpdateGateway,
+                )
+              : Text.rich(
+                  TextSpan(
+                    style: textTheme.bodySmall?.copyWith(
+                      color: colorScheme.onSurface.withValues(alpha: 0.72),
+                    ),
+                    children: const [
+                      TextSpan(
+                        text:
+                            'No devices offer VPN gateway. Ask a remote device to enable '
+                            "'Serve as VPN Gateway' on their device, and to allow you in their peer settings.\n",
+                      ),
+                      TextSpan(text: 'Or open Settings to become a gateway yourself.'),
+                    ],
+                  ),
+                ),
+        ),
+      ],
+    );
+  }
+}
+
+class _GatewayExitRow extends StatelessWidget {
+  final String selectedPeerID;
+  final String selectedName;
+  final List<AvailableVPNGateway> gateways;
+  final bool enabled;
+  final bool connected;
+  final Duration exitPing;
+  final bool exitThroughRelay;
+  final String exitPublicIP;
+  final Future<String> Function(String gatewayPeerID)? onUpdateGateway;
+
+  const _GatewayExitRow({
+    required this.selectedPeerID,
+    required this.selectedName,
+    required this.gateways,
+    required this.enabled,
+    required this.connected,
+    required this.exitPing,
+    required this.exitThroughRelay,
+    required this.exitPublicIP,
+    required this.onUpdateGateway,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final options = <_ExitPeerOption>[const _ExitPeerOption('None')];
+    for (final n in gateways) {
+      options.add(_ExitPeerOption(n.peerName, connected: n.connected));
+    }
+    var displayName = selectedName.isEmpty ? 'None' : selectedName;
+    if (displayName != 'None' && !options.any((o) => o.name == displayName)) {
+      // Selection points to a peer not in the candidate list — surface it
+      // as a disconnected option so the dropdown stays consistent.
+      options.add(_ExitPeerOption(displayName, connected: false));
+    }
+
+    Widget? triggerLeading;
+    if (enabled && displayName != 'None') {
+      triggerLeading = Padding(
+        padding: const EdgeInsets.only(right: 8),
+        child: _ConnectedDot(connected: connected),
+      );
+    }
+
+    return _ExitPickerCore(
+      options: options,
+      selected: displayName,
+      triggerLeading: triggerLeading,
+      metaLine: enabled && connected
+          ? _buildExitMeta(
+              context,
+              connected: true,
+              ping: exitPing,
+              throughRelay: exitThroughRelay,
+              publicIP: exitPublicIP,
+            )
+          : null,
+      onPick: (picked) => _apply(context, picked),
+    );
+  }
+
+  Future<void> _apply(BuildContext context, String name) async {
+    if (onUpdateGateway == null) return;
+    var exitPeerID = '';
+    if (name != 'None') {
+      final found = gateways.firstWhere(
+        (e) => e.peerName == name,
+        orElse: () => AvailableVPNGateway('', name, false),
+      );
+      if (found.peerID.isEmpty) return;
+      exitPeerID = found.peerID;
+    }
+    final response = await onUpdateGateway!(exitPeerID);
+    if (!context.mounted) return;
+    if (response.isNotEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          backgroundColor: Theme.of(context).colorScheme.error,
+          content: Text('Failed to update VPN gateway: $response'),
+        ),
+      );
+      return;
+    }
+    // Routing is applied at runtime: onUpdateGateway (in the page adapter) calls
+    // reconfigureVpn(), which on Android re-establishes the VPN and hot-swaps the
+    // tun fd into the backend. No app restart is required.
   }
 }
 
@@ -347,11 +600,17 @@ class _StatTile extends StatelessWidget {
       visualDensity: VisualDensity.compact,
       leading: Icon(icon, color: colorScheme.onSurfaceVariant),
       title: Text(label, style: textTheme.bodyLarge),
-      subtitle: Text(
-        '${byteCountIEC(totalBytes)} total',
-        style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurface.withValues(alpha: 0.72)),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text('${byteCountIEC(rateBytesPerSec.round())}/s', style: textTheme.bodyLarge),
+          const SizedBox(width: 8),
+          Text(
+            '· ${byteCountIEC(totalBytes)}',
+            style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurface.withValues(alpha: 0.6)),
+          ),
+        ],
       ),
-      trailing: Text('${byteCountIEC(rateBytesPerSec.round())}/s', style: textTheme.bodyLarge),
     );
   }
 }
@@ -409,9 +668,9 @@ class _LabeledTile extends StatelessWidget {
 String? _reachabilitySubtitle(String reachability) {
   switch (reachability) {
     case 'Public':
-      return 'Other peers can connect to you directly.';
+      return 'Other devices can connect to you directly.';
     case 'Private':
-      return 'Other peers reach you via a relay.';
+      return 'Other devices reach you via a relay.';
     default:
       return null;
   }
@@ -503,62 +762,57 @@ class _AddressField extends StatelessWidget {
 class _ExitThroughRow extends StatelessWidget {
   final String currentName;
   final ListAvailableProxiesResponse? proxiesData;
+  final bool upstreamKnownOffline;
+  final String usingPublicIP;
+  final Duration usingPing;
+  final bool usingThroughRelay;
   final Future<String> Function(String usingPeerID)? onUpdateProxy;
 
-  const _ExitThroughRow({required this.currentName, required this.proxiesData, required this.onUpdateProxy});
+  const _ExitThroughRow({
+    required this.currentName,
+    required this.proxiesData,
+    required this.upstreamKnownOffline,
+    required this.usingPublicIP,
+    required this.usingPing,
+    required this.usingThroughRelay,
+    required this.onUpdateProxy,
+  });
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-    final textTheme = Theme.of(context).textTheme;
-
     final displayName = currentName.isEmpty ? 'None' : currentName;
-    final names = <String>['None'];
+    final options = <_ExitPeerOption>[const _ExitPeerOption('None')];
     if (proxiesData != null) {
       for (final p in proxiesData!.proxies) {
-        names.add(p.peerName);
+        options.add(_ExitPeerOption(p.peerName, connected: p.connected));
       }
     }
-    if (displayName != 'None' && !names.contains(displayName)) {
-      names.add(displayName);
+    if (displayName != 'None' && !options.any((o) => o.name == displayName)) {
+      options.add(_ExitPeerOption(displayName, connected: false));
     }
 
-    final labelColumn = Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Text('Exit through', style: textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w500)),
-        const SizedBox(height: 2),
-        Text(
-          'Proxied traffic leaves the internet from this peer.',
-          style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurface.withValues(alpha: 0.72)),
-        ),
-      ],
-    );
+    Widget? triggerLeading;
+    if (displayName != 'None') {
+      triggerLeading = Padding(
+        padding: const EdgeInsets.only(right: 8),
+        child: _ConnectedDot(connected: !upstreamKnownOffline),
+      );
+    }
 
-    final dropdown = _ExitPeerDropdown(
-      names: names,
+    return _ExitPickerCore(
+      options: options,
       selected: displayName,
+      triggerLeading: triggerLeading,
+      metaLine: !upstreamKnownOffline
+          ? _buildExitMeta(
+              context,
+              connected: true,
+              ping: usingPing,
+              throughRelay: usingThroughRelay,
+              publicIP: usingPublicIP,
+            )
+          : null,
       onPick: (picked) => _apply(context, picked),
-    );
-
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        if (constraints.maxWidth < 320) {
-          return Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [labelColumn, const SizedBox(height: 10), dropdown],
-          );
-        }
-        return Row(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            Expanded(child: labelColumn),
-            const SizedBox(width: 12),
-            SizedBox(width: 180, child: dropdown),
-          ],
-        );
-      },
     );
   }
 
@@ -570,7 +824,7 @@ class _ExitThroughRow extends StatelessWidget {
       if (proxies == null) return;
       final found = proxies.proxies.firstWhere(
         (e) => e.peerName == name,
-        orElse: () => AvailableProxy('', name),
+        orElse: () => AvailableProxy('', name, false),
       );
       usingPeerID = found.peerID;
     }
@@ -587,12 +841,86 @@ class _ExitThroughRow extends StatelessWidget {
   }
 }
 
-class _ExitPeerDropdown extends StatelessWidget {
-  final List<String> names;
+/// One option in the exit-peer picker. [connected] is `null` for entries
+/// that have no online/offline meaning (e.g. "None"); a `bool` value is
+/// rendered as a green/dim leading dot in items.
+class _ExitPeerOption {
+  final String name;
+  final bool? connected;
+
+  const _ExitPeerOption(this.name, {this.connected});
+}
+
+/// Small leading dot rendered for items that carry an online/offline state.
+/// Solid green for connected peers, dim hollow for disconnected.
+class _ConnectedDot extends StatelessWidget {
+  final bool connected;
+
+  const _ConnectedDot({required this.connected});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Icon(
+      connected ? Icons.circle : Icons.circle_outlined,
+      size: 10,
+      color: connected ? successColor : colorScheme.onSurfaceVariant,
+    );
+  }
+}
+
+/// Shared layout for the SOCKS5 / VPN-Gateway exit-peer pickers:
+///
+///   [ Exit peer ────────────────────────────────────────── ]
+///   [ ● awl-tester                                       ▼ ]
+///   ● Direct · 21 ms · Public IP: 203.0.113.45
+///
+/// Full-width dropdown matches the [_AddressField] pattern in the same
+/// card — both are Material outlined inputs with a floating label, so the
+/// card reads as one consistent form. Optional [metaLine] sits inline
+/// below. The two cards differ in their data sources, async update
+/// endpoints, and success-side-effects — those stay in the per-card
+/// wrappers; this widget owns only the visual composition.
+class _ExitPickerCore extends StatelessWidget {
+  final List<_ExitPeerOption> options;
   final String selected;
+  final Widget? triggerLeading;
+  final Widget? metaLine;
+  final Future<void> Function(String pickedName) onPick;
+
+  const _ExitPickerCore({
+    required this.options,
+    required this.selected,
+    required this.triggerLeading,
+    required this.metaLine,
+    required this.onPick,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _ExitPeerDropdown(options: options, selected: selected, leading: triggerLeading, onPick: onPick),
+        if (metaLine != null) ...[const SizedBox(height: 8), metaLine!],
+      ],
+    );
+  }
+}
+
+class _ExitPeerDropdown extends StatelessWidget {
+  final List<_ExitPeerOption> options;
+  final String selected;
+  final Widget? leading;
   final Future<void> Function(String) onPick;
 
-  const _ExitPeerDropdown({required this.names, required this.selected, required this.onPick});
+  const _ExitPeerDropdown({
+    required this.options,
+    required this.selected,
+    required this.onPick,
+    this.leading,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -615,6 +943,7 @@ class _ExitPeerDropdown extends StatelessWidget {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
+          ?leading,
           Expanded(
             child: Text(
               selected,
@@ -631,7 +960,7 @@ class _ExitPeerDropdown extends StatelessWidget {
       return InkWell(
         borderRadius: BorderRadius.circular(12),
         onTap: () async {
-          final picked = await _showExitPeerSheet(context, names, selected);
+          final picked = await _showExitPeerSheet(context, options, selected);
           if (picked == null || picked == selected) return;
           if (!context.mounted) return;
           await onPick(picked);
@@ -644,12 +973,28 @@ class _ExitPeerDropdown extends StatelessWidget {
       tooltip: '',
       initialValue: selected,
       onSelected: onPick,
-      itemBuilder: (_) => names.map((n) => PopupMenuItem<String>(value: n, child: Text(n))).toList(),
+      itemBuilder: (_) => options
+          .map(
+            (o) => PopupMenuItem<String>(
+              value: o.name,
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (o.connected != null) ...[
+                    _ConnectedDot(connected: o.connected!),
+                    const SizedBox(width: 10),
+                  ],
+                  Text(o.name),
+                ],
+              ),
+            ),
+          )
+          .toList(),
       child: trigger,
     );
   }
 
-  Future<String?> _showExitPeerSheet(BuildContext context, List<String> names, String selected) {
+  Future<String?> _showExitPeerSheet(BuildContext context, List<_ExitPeerOption> options, String selected) {
     return showModalBottomSheet<String>(
       context: context,
       showDragHandle: true,
@@ -668,7 +1013,22 @@ class _ExitPeerDropdown extends StatelessWidget {
                 onChanged: (value) => Navigator.of(context).pop(value),
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
-                  children: names.map((n) => RadioListTile<String>(title: Text(n), value: n)).toList(),
+                  children: options
+                      .map(
+                        (o) => RadioListTile<String>(
+                          value: o.name,
+                          title: Row(
+                            children: [
+                              if (o.connected != null) ...[
+                                _ConnectedDot(connected: o.connected!),
+                                const SizedBox(width: 12),
+                              ],
+                              Expanded(child: Text(o.name)),
+                            ],
+                          ),
+                        ),
+                      )
+                      .toList(),
                 ),
               ),
               const SizedBox(height: 8),
@@ -678,6 +1038,60 @@ class _ExitPeerDropdown extends StatelessWidget {
       },
     );
   }
+}
+
+/// One-line live metadata about the active exit, shown below the picker:
+/// colored leading dot (green for direct, amber for via-relay), mode + ping,
+/// and the observed Public IP — joined with " · ". Wraps on narrow widths.
+/// Returns `null` when there's nothing to show (e.g. not connected and no IP).
+Widget? _buildExitMeta(
+  BuildContext context, {
+  required bool connected,
+  required Duration ping,
+  required bool throughRelay,
+  required String publicIP,
+}) {
+  final colorScheme = Theme.of(context).colorScheme;
+  final textTheme = Theme.of(context).textTheme;
+  final baseStyle = textTheme.bodySmall?.copyWith(color: colorScheme.onSurface.withValues(alpha: 0.85));
+  final dimStyle = textTheme.bodySmall?.copyWith(color: colorScheme.onSurface.withValues(alpha: 0.72));
+
+  String? modePing;
+  Color? dotColor;
+  if (connected) {
+    final mode = throughRelay ? 'Via relay' : 'Direct';
+    final ms = ping.inMilliseconds;
+    modePing = ms > 0 ? '$mode · $ms ms' : mode;
+    dotColor = throughRelay ? warningColor : successColor;
+  }
+
+  if (modePing == null && publicIP.isEmpty) return null;
+
+  // Multiple separate widgets (vs Text.rich) so widget tests can find each
+  // segment with `find.text(...)`. Wrap keeps it visually inline.
+  final children = <Widget>[];
+  if (dotColor != null) {
+    children.add(
+      Container(
+        width: 8,
+        height: 8,
+        decoration: BoxDecoration(color: dotColor, shape: BoxShape.circle),
+      ),
+    );
+    children.add(const SizedBox(width: 8));
+  }
+  if (modePing != null) {
+    children.add(Text(modePing, style: baseStyle));
+  }
+  if (modePing != null && publicIP.isNotEmpty) {
+    children.add(Text(' · ', style: dimStyle));
+  }
+  if (publicIP.isNotEmpty) {
+    children.add(Text('Public IP: ', style: dimStyle));
+    children.add(SelectableText(publicIP, style: baseStyle?.copyWith(fontFamily: 'monospace')));
+  }
+
+  return Wrap(crossAxisAlignment: WrapCrossAlignment.center, children: children);
 }
 
 Widget buildDeviceHeader(
@@ -809,6 +1223,8 @@ class _SettingsFormState extends ConsumerState<SettingsForm> {
               textInputAction: TextInputAction.done,
             ),
           ),
+          _BeGatewaySwitch(initial: widget.peerInfo?.vpnGateway.serverEnabled ?? false),
+          SizedBox(height: 20),
           Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
@@ -827,8 +1243,102 @@ class _SettingsFormState extends ConsumerState<SettingsForm> {
               ),
             ],
           ),
+          SizedBox(height: 8),
         ],
       ),
     );
+  }
+}
+
+/// "Serve as VPN Gateway" toggle. Lives inside [SettingsForm] but applies its
+/// own state independently — the backend has a dedicated endpoint and
+/// flipping this is rare and consequential, so we don't bundle it with the
+/// peer-name save button.
+class _BeGatewaySwitch extends ConsumerStatefulWidget {
+  final bool initial;
+
+  const _BeGatewaySwitch({required this.initial});
+
+  @override
+  ConsumerState<_BeGatewaySwitch> createState() => _BeGatewaySwitchState();
+}
+
+class _BeGatewaySwitchState extends ConsumerState<_BeGatewaySwitch> {
+  late bool _value = widget.initial;
+  bool _busy = false;
+
+  bool get _androidUnsupported => !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
+
+  Future<void> _toggle(bool next) async {
+    if (_busy) return;
+    if (next) {
+      final ok = await _confirm();
+      if (ok != true) return;
+    }
+    setState(() => _busy = true);
+    final response = await ref.read(apiProvider).setVPNGatewayServerEnabled(next);
+    if (!mounted) return;
+    setState(() => _busy = false);
+    if (response.isNotEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          backgroundColor: Theme.of(context).colorScheme.error,
+          content: Text('Failed to update VPN gateway mode: $response'),
+        ),
+      );
+      return;
+    }
+    setState(() => _value = next);
+    await ref.read(myPeerInfoProvider.notifier).refresh();
+  }
+
+  Future<bool?> _confirm() {
+    return showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Serve as VPN Gateway'),
+        content: const Text(
+          'Devices you permit will be able to route their internet traffic through this device. '
+          'Their traffic will appear to come from your IP address. Make sure you trust them.',
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(context, false), child: const Text('Cancel')),
+          FilledButton(onPressed: () => Navigator.pop(context, true), child: const Text('Enable')),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final disabled = _androidUnsupported || _busy;
+    final tile = SwitchListTile(
+      contentPadding: const EdgeInsets.symmetric(horizontal: 8),
+      title: Row(
+        children: [
+          const Flexible(child: Text('Serve as VPN Gateway')),
+          if (_androidUnsupported) ...[
+            const SizedBox(width: 6),
+            Tooltip(
+              triggerMode: TooltipTriggerMode.tap,
+              message:
+                  'Not supported on Android: serving as a VPN gateway requires '
+                  "NAT/iptables configuration that Android apps can't perform without root.",
+              child: Icon(Icons.info_outline, size: 18, color: colorScheme.onSurfaceVariant),
+            ),
+          ],
+        ],
+      ),
+      subtitle: Text(
+        _androidUnsupported
+            ? 'Not supported on Android.'
+            : 'Let permitted devices route their internet traffic through this device.',
+        style: TextStyle(color: colorScheme.onSurfaceVariant),
+      ),
+      value: _androidUnsupported ? false : _value,
+      onChanged: disabled ? null : _toggle,
+    );
+    return tile;
   }
 }

--- a/test/fixtures/available_proxies.json
+++ b/test/fixtures/available_proxies.json
@@ -2,7 +2,8 @@
     "Proxies": [
         {
             "PeerID": "12D3KooWJMUjt9b5T1umzgzjLv5yG2ViuuF4qjmN65tsRXZGS1p8",
-            "PeerName": "awl-tester"
+            "PeerName": "awl-tester",
+            "Connected": true
         }
     ]
 }

--- a/test/fixtures/known_peers.json
+++ b/test/fixtures/known_peers.json
@@ -12,6 +12,7 @@
         "Declined": false,
         "WeAllowUsingAsExitNode": false,
         "AllowedUsingAsExitNode": true,
+        "RemoteVPNGatewayServerEnabled": false,
         "LastSeen": "2026-04-10T08:24:50.522115354+03:00",
         "Connections": [
             {

--- a/test/fixtures/my_peer_info.json
+++ b/test/fixtures/my_peer_info.json
@@ -29,7 +29,21 @@
         "ListenAddress": "127.0.0.66:8080",
         "ProxyingEnabled": true,
         "ListenerEnabled": true,
+        "Connected": true,
         "UsingPeerID": "12D3KooWJMUjt9b5T1umzgzjLv5yG2ViuuF4qjmN65tsRXZGS1p8",
-        "UsingPeerName": "awl-tester"
+        "UsingPeerName": "awl-tester",
+        "UsingPeerPublicIP": "203.0.113.45",
+        "UsingPeerPing": 21000000,
+        "UsingPeerThroughRelay": false
+    },
+    "VPNGateway": {
+        "ClientEnabled": false,
+        "GatewayPeerID": "",
+        "GatewayPeerName": "",
+        "Connected": false,
+        "ServerEnabled": false,
+        "GatewayPublicIP": "",
+        "GatewayPing": 0,
+        "GatewayThroughRelay": false
     }
 }

--- a/test/unit/api_test.dart
+++ b/test/unit/api_test.dart
@@ -293,5 +293,79 @@ void main() {
       final result = await api.removePeer('pid');
       expect(result, 'cannot remove');
     });
+
+    test('enableVPNGatewayClient sends GatewayPeerID and returns empty on success', () async {
+      when(() => client.send(any())).thenAnswer((_) async => _streamed('{"message":"ok"}', 200));
+
+      final result = await api.enableVPNGatewayClient('gw-pid');
+      expect(result, '');
+
+      final captured = verify(() => client.send(captureAny())).captured.single as http.Request;
+      expect(captured.url.toString(), '$_baseUrl$enableVPNGatewayClientPath');
+      final decoded = jsonDecode(captured.body) as Map<String, dynamic>;
+      expect(decoded['GatewayPeerID'], 'gw-pid');
+    });
+
+    test('enableVPNGatewayClient returns error on non-200', () async {
+      when(() => client.send(any())).thenAnswer((_) async => _streamed('{"error":"peer not allowed"}', 400));
+
+      final result = await api.enableVPNGatewayClient('gw-pid');
+      expect(result, 'peer not allowed');
+    });
+
+    test('disableVPNGatewayClient POSTs an empty body to disable path', () async {
+      when(() => client.send(any())).thenAnswer((_) async => _streamed('{"message":"ok"}', 200));
+
+      final result = await api.disableVPNGatewayClient();
+      expect(result, '');
+
+      final captured = verify(() => client.send(captureAny())).captured.single as http.Request;
+      expect(captured.url.toString(), '$_baseUrl$disableVPNGatewayClientPath');
+      expect(captured.body, '{}');
+    });
+
+    test('setVPNGatewayServerEnabled sends Enabled flag', () async {
+      when(() => client.send(any())).thenAnswer((_) async => _streamed('{"message":"ok"}', 200));
+
+      final result = await api.setVPNGatewayServerEnabled(true);
+      expect(result, '');
+
+      final captured = verify(() => client.send(captureAny())).captured.single as http.Request;
+      expect(captured.url.toString(), '$_baseUrl$setVPNGatewayServerEnabledPath');
+      final decoded = jsonDecode(captured.body) as Map<String, dynamic>;
+      expect(decoded['Enabled'], true);
+    });
+  });
+
+  group('VPN Gateway GET endpoints', () {
+    late MockHttpClient client;
+    late ApiClient api;
+
+    setUp(() {
+      client = MockHttpClient();
+      api = ApiClient(client);
+      serverAddress = _baseUrl;
+    });
+
+    test('fetchAvailableVPNGateways parses response', () async {
+      when(() => client.get(any<Uri>())).thenAnswer(
+        (_) async => http.Response('{"VPNGateways":[{"PeerID":"p1","PeerName":"n1","Connected":true}]}', 200),
+      );
+
+      final res = await api.fetchAvailableVPNGateways();
+      expect(res.vpnGateways, hasLength(1));
+      expect(res.vpnGateways.first.peerID, 'p1');
+      expect(res.vpnGateways.first.peerName, 'n1');
+      expect(res.vpnGateways.first.connected, true);
+
+      verify(() => client.get(Uri.parse('$_baseUrl$listAvailableVPNGatewaysPath'))).called(1);
+    });
+
+    test('fetchAvailableVPNGateways accepts null/missing VPNGateways', () async {
+      when(() => client.get(any<Uri>())).thenAnswer((_) async => http.Response('{"VPNGateways":null}', 200));
+
+      final res = await api.fetchAvailableVPNGateways();
+      expect(res.vpnGateways, isEmpty);
+    });
   });
 }

--- a/test/widget/peers_list_tab_test.dart
+++ b/test/widget/peers_list_tab_test.dart
@@ -75,5 +75,32 @@ void main() {
       expect(qrPeer, isNotNull);
       expect(qrPeer!.peerID, peers.first.peerID);
     });
+
+    // The expanded details switch between a 2-column grid and single-column
+    // rows based on the panel's actual width (LayoutBuilder), not the screen.
+    // The grid is the only place that uses a [Wrap], so its presence/absence
+    // distinguishes the two layouts.
+
+    testWidgets('expanded peer details use a 2-column grid on a wide panel', (tester) async {
+      final peers = _loadPeers();
+      await pumpAppWidget(tester, PeersListView(peers: peers), size: const Size(1200, 900));
+
+      await tester.tap(find.text(peers.first.displayName));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Use as exit'), findsOneWidget); // details rendered
+      expect(find.byType(Wrap), findsWidgets); // grid layout
+    });
+
+    testWidgets('expanded peer details fall back to single-column rows on a narrow panel', (tester) async {
+      final peers = _loadPeers();
+      await pumpAppWidget(tester, PeersListView(peers: peers), size: const Size(420, 900));
+
+      await tester.tap(find.text(peers.first.displayName));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Use as exit'), findsOneWidget); // details rendered
+      expect(find.byType(Wrap), findsNothing); // single-column rows, no grid
+    });
   });
 }

--- a/test/widget/status_tab_test.dart
+++ b/test/widget/status_tab_test.dart
@@ -29,6 +29,41 @@ MyPeerInfo _withBootstrap(MyPeerInfo base, int connected) {
     base.awlDNSAddress,
     base.isAwlDNSSetAsSystem,
     base.socks5,
+    base.vpnGateway,
+  );
+}
+
+MyPeerInfo _withGateway(MyPeerInfo base, VPNGatewayInfo gateway) {
+  return MyPeerInfo(
+    base.peerID,
+    base.name,
+    base.uptime,
+    base.serverVersion,
+    base.networkStats,
+    base.totalBootstrapPeers,
+    base.connectedBootstrapPeers,
+    base.reachability,
+    base.awlDNSAddress,
+    base.isAwlDNSSetAsSystem,
+    base.socks5,
+    gateway,
+  );
+}
+
+MyPeerInfo _withSocks5(MyPeerInfo base, SOCKS5Info socks5) {
+  return MyPeerInfo(
+    base.peerID,
+    base.name,
+    base.uptime,
+    base.serverVersion,
+    base.networkStats,
+    base.totalBootstrapPeers,
+    base.connectedBootstrapPeers,
+    base.reachability,
+    base.awlDNSAddress,
+    base.isAwlDNSSetAsSystem,
+    socks5,
+    base.vpnGateway,
   );
 }
 
@@ -63,15 +98,18 @@ void main() {
       // Card titles.
       expect(find.text('Network'), findsOneWidget);
       expect(find.text('SOCKS5 proxy'), findsOneWidget);
+      expect(find.text('VPN Gateway'), findsOneWidget);
+      // Gateway is off in the fixture.
+      expect(find.text('Off'), findsOneWidget);
 
       // Body labels.
       expect(find.text('Download'), findsOneWidget);
       expect(find.text('Upload'), findsOneWidget);
       expect(find.text('Reachability'), findsOneWidget);
-      expect(find.text('Discovery nodes'), findsOneWidget);
-
-      // Bootstrap value uses "connected / total" — fixture has 4/5 (healthy, no warning).
-      expect(find.text('4 / 5'), findsOneWidget);
+      // Discovery row hidden at full health (fixture: 4/5 connected ≥2).
+      // The pill in the header carries the network state instead.
+      expect(find.text('Discovery nodes'), findsNothing);
+      expect(find.text('Online'), findsOneWidget);
 
       // SOCKS5 listener is enabled in the fixture, so the address row appears.
       expect(find.text('Address'), findsOneWidget);
@@ -80,8 +118,11 @@ void main() {
       // SOCKS5 active state.
       expect(find.text('Active'), findsOneWidget);
 
-      // Exit peer label and current selection.
-      expect(find.text('Exit through'), findsOneWidget);
+      // Exit peer floating label (inside the dropdown's OutlineInputBorder)
+      // and the current selection. The outer "Exit through" label was
+      // removed — the inner floating label is the only label now, matching
+      // the Address field's pattern.
+      expect(find.text('Exit peer'), findsAtLeastNWidgets(1));
       expect(find.text('awl-tester'), findsOneWidget);
 
       // Reachability is "Unknown" in the fixture.
@@ -147,6 +188,267 @@ void main() {
 
       expect(find.text('1 / 5'), findsOneWidget);
       expect(find.byIcon(Icons.warning_amber_rounded), findsOneWidget);
+    });
+
+    testWidgets('Gateway card shows empty-state hint when off and no candidates', (tester) async {
+      final base = _withGateway(
+        _loadInfo(),
+        VPNGatewayInfo(false, '', '', false, false, '', Duration.zero, false),
+      );
+      await pumpAppWidget(
+        tester,
+        StatusPageView(
+          peerInfo: base,
+          proxiesData: _loadProxies(),
+          gatewaysData: ListAvailableVPNGatewaysResponse(const []),
+        ),
+        size: desktopSize,
+      );
+
+      expect(find.text('VPN Gateway'), findsOneWidget);
+      expect(find.text('Off'), findsOneWidget);
+      expect(find.textContaining('No devices offer VPN gateway'), findsOneWidget);
+      expect(find.textContaining('Or open Settings to become a gateway yourself'), findsOneWidget);
+      // Gateway dropdown is hidden in empty state — only the SOCKS5 dropdown renders 'Exit peer'.
+      expect(find.text('Exit peer'), findsOneWidget);
+    });
+
+    testWidgets('Gateway card shows Active pill and selected exit-node name when connected', (tester) async {
+      final base = _withGateway(
+        _loadInfo(),
+        VPNGatewayInfo(
+          true,
+          'peer-vasya',
+          'vasya-laptop',
+          true,
+          false,
+          '203.0.113.45',
+          const Duration(milliseconds: 21),
+          false,
+        ),
+      );
+      await pumpAppWidget(
+        tester,
+        StatusPageView(
+          peerInfo: base,
+          proxiesData: _loadProxies(),
+          gatewaysData: ListAvailableVPNGatewaysResponse([
+            AvailableVPNGateway('peer-vasya', 'vasya-laptop', true),
+          ]),
+        ),
+        size: desktopSize,
+      );
+
+      // Active pill (rendered for both SOCKS5 and Gateway in this fixture).
+      expect(find.text('Active'), findsNWidgets(2));
+      // Selected name appears once — inside the dropdown trigger only,
+      // not duplicated by a separate "Exit node:" line.
+      expect(find.text('vasya-laptop'), findsOneWidget);
+      expect(find.textContaining('Exit node:'), findsNothing);
+    });
+
+    testWidgets('Gateway card shows Connecting pill when enabled but not yet connected', (tester) async {
+      final base = _withGateway(
+        _loadInfo(),
+        VPNGatewayInfo(true, 'peer-vasya', 'vasya-laptop', false, false, '', Duration.zero, false),
+      );
+      await pumpAppWidget(
+        tester,
+        StatusPageView(
+          peerInfo: base,
+          proxiesData: _loadProxies(),
+          gatewaysData: ListAvailableVPNGatewaysResponse([
+            AvailableVPNGateway('peer-vasya', 'vasya-laptop', false),
+          ]),
+        ),
+        size: desktopSize,
+      );
+
+      expect(find.text('Connecting…'), findsOneWidget);
+    });
+
+    testWidgets('Gateway dropdown picks an exit node and invokes onUpdateGateway', (tester) async {
+      final base = _withGateway(
+        _loadInfo(),
+        VPNGatewayInfo(false, '', '', false, false, '', Duration.zero, false),
+      );
+      String? receivedPeerID;
+      await pumpAppWidget(
+        tester,
+        StatusPageView(
+          peerInfo: base,
+          proxiesData: _loadProxies(),
+          gatewaysData: ListAvailableVPNGatewaysResponse([
+            AvailableVPNGateway('peer-vasya', 'vasya-laptop', true),
+          ]),
+          onUpdateGateway: (id) async {
+            receivedPeerID = id;
+            return '';
+          },
+        ),
+        size: desktopSize,
+      );
+
+      // Open the dropdown (PopupMenuButton on desktop).
+      await tester.tap(find.text('None').last);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('vasya-laptop').last);
+      await tester.pumpAndSettle();
+
+      expect(receivedPeerID, 'peer-vasya');
+    });
+
+    testWidgets('Network header shows Online pill at full health (no Discovery row)', (tester) async {
+      await pumpAppWidget(
+        tester,
+        StatusPageView(peerInfo: _withBootstrap(_loadInfo(), 5), proxiesData: _loadProxies()),
+        size: desktopSize,
+      );
+
+      expect(find.text('Online'), findsOneWidget);
+      expect(find.text('Discovery nodes'), findsNothing);
+      expect(find.byIcon(Icons.warning_amber_rounded), findsNothing);
+    });
+
+    testWidgets('Network header shows Offline pill at zero connected', (tester) async {
+      await pumpAppWidget(
+        tester,
+        StatusPageView(peerInfo: _withBootstrap(_loadInfo(), 0), proxiesData: _loadProxies()),
+        size: desktopSize,
+      );
+
+      expect(find.text('Offline'), findsOneWidget);
+      // Discovery row stays visible at low health.
+      expect(find.text('Discovery nodes'), findsOneWidget);
+    });
+
+    testWidgets('SOCKS5 pill flips to Connecting when SOCKS5Info.connected is false', (tester) async {
+      final base = _loadInfo();
+      // Override Connected to false; SOCKS5Info.connected is now the source
+      // of truth for the pill, not a cross-lookup in proxiesData.
+      final socks5 = SOCKS5Info(
+        base.socks5.listenAddress,
+        base.socks5.proxyingEnabled,
+        base.socks5.listenerEnabled,
+        false,
+        base.socks5.usingPeerID,
+        base.socks5.usingPeerName,
+        base.socks5.usingPeerPublicIP,
+        base.socks5.usingPeerPing,
+        base.socks5.usingPeerThroughRelay,
+      );
+      await pumpAppWidget(
+        tester,
+        StatusPageView(peerInfo: _withSocks5(base, socks5), proxiesData: _loadProxies()),
+        size: desktopSize,
+      );
+
+      expect(find.text('Connecting…'), findsOneWidget);
+      // The selected name still shows in the dropdown trigger.
+      expect(find.text(base.socks5.usingPeerName), findsOneWidget);
+    });
+
+    testWidgets('SOCKS5 empty-state hint shows when no candidates and nothing selected', (tester) async {
+      final base = _loadInfo();
+      // Wipe the upstream selection so we hit the empty-state branch.
+      final socks5 = SOCKS5Info(
+        base.socks5.listenAddress,
+        base.socks5.proxyingEnabled,
+        base.socks5.listenerEnabled,
+        false,
+        '',
+        '',
+        '',
+        Duration.zero,
+        false,
+      );
+      await pumpAppWidget(
+        tester,
+        StatusPageView(
+          peerInfo: _withSocks5(base, socks5),
+          proxiesData: ListAvailableProxiesResponse(const []),
+        ),
+        size: desktopSize,
+      );
+
+      expect(find.textContaining('every connection will fail'), findsOneWidget);
+    });
+
+    testWidgets('Gateway active state renders Direct/ping status line and Public IP row', (tester) async {
+      const exitID = 'peer-vasya';
+      const exitName = 'vasya-laptop';
+      const exitIP = '198.51.100.7';
+      var base = _loadInfo();
+      // Clear SOCKS5 upstream so its Public IP row doesn't compete with the
+      // gateway's in this assertion.
+      base = _withSocks5(
+        base,
+        SOCKS5Info(
+          base.socks5.listenAddress,
+          base.socks5.proxyingEnabled,
+          base.socks5.listenerEnabled,
+          false,
+          '',
+          '',
+          '',
+          Duration.zero,
+          false,
+        ),
+      );
+      base = _withGateway(
+        base,
+        VPNGatewayInfo(true, exitID, exitName, true, false, exitIP, const Duration(milliseconds: 21), false),
+      );
+      await pumpAppWidget(
+        tester,
+        StatusPageView(
+          peerInfo: base,
+          proxiesData: ListAvailableProxiesResponse(const []),
+          gatewaysData: ListAvailableVPNGatewaysResponse([AvailableVPNGateway(exitID, exitName, true)]),
+        ),
+        size: desktopSize,
+      );
+
+      // Status line: "Direct · 21 ms".
+      expect(find.text('Direct · 21 ms'), findsOneWidget);
+      // Public IP row.
+      expect(find.text('Public IP: '), findsOneWidget);
+      expect(find.text(exitIP), findsOneWidget);
+    });
+
+    testWidgets('Gateway via-relay status line renders when no direct connection exists', (tester) async {
+      const exitID = 'peer-vasya';
+      const exitName = 'vasya-laptop';
+      var base = _loadInfo();
+      base = _withSocks5(
+        base,
+        SOCKS5Info(
+          base.socks5.listenAddress,
+          base.socks5.proxyingEnabled,
+          base.socks5.listenerEnabled,
+          false,
+          '',
+          '',
+          '',
+          Duration.zero,
+          false,
+        ),
+      );
+      base = _withGateway(
+        base,
+        VPNGatewayInfo(true, exitID, exitName, true, false, '', const Duration(milliseconds: 80), true),
+      );
+      await pumpAppWidget(
+        tester,
+        StatusPageView(
+          peerInfo: base,
+          proxiesData: ListAvailableProxiesResponse(const []),
+          gatewaysData: ListAvailableVPNGatewaysResponse([AvailableVPNGateway(exitID, exitName, true)]),
+        ),
+        size: desktopSize,
+      );
+
+      expect(find.text('Via relay · 80 ms'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
For PR https://github.com/anywherelan/awl/pull/243
For https://github.com/anywherelan/awl/issues/138

- VPN Gateway client/server: API, provider, entities, Android runtime TUN hot-swap (reconfigure_vpn) for full-tunnel routing without restart
- Redesigned Status (Network/Gateway/SOCKS5 cards) and Peers (expandable cards, exit badges); width-capped both columns, peer-details breakpoint by actual width